### PR TITLE
Add Category and SubCategory to PostViewDto mappings

### DIFF
--- a/Dentizone.Application/AutoMapper/Posts/PostProfile.cs
+++ b/Dentizone.Application/AutoMapper/Posts/PostProfile.cs
@@ -18,6 +18,8 @@ namespace Dentizone.Application.AutoMapper.Posts
             CreateMap<Post, PostViewDto>()
                 .ForMember(dest => dest.Assets, opt => opt.MapFrom(src => src.PostAssets))
                 .ForMember(dest => dest.Seller, opt => opt.MapFrom(src => src.Seller))
+                .ForMember(dest => dest.Category, opt => opt.MapFrom(src => src.Category.Name))
+                .ForMember(dest => dest.SubCatgory, opt => opt.MapFrom(src => src.SubCategory.Name))
                 .ReverseMap();
         }
     }

--- a/Dentizone.Application/DTOs/PostDTO/PostViewDTO.cs
+++ b/Dentizone.Application/DTOs/PostDTO/PostViewDTO.cs
@@ -10,6 +10,8 @@ namespace Dentizone.Application.DTOs.PostDTO
         public decimal Price { get; set; }
         public DateTime? ExpireDate { get; set; }
         public string Condition { get; set; }
+        public string Category { get; set; }
+        public string SubCatgory { get; set; }
         public string Status { get; set; }
         public UserView Seller { get; set; }
         public List<PostAssetView> Assets { get; set; }

--- a/Dentizone.Application/Services/PostService.cs
+++ b/Dentizone.Application/Services/PostService.cs
@@ -308,6 +308,8 @@ namespace Dentizone.Application.Services
                                           .Include(p => p.PostAssets).ThenInclude(pa => pa.Asset)
                                           .Include(p => p.Seller)
                                           .ThenInclude(p => p.University)
+                                          .Include(p => p.Category)
+                                          .Include(p => p.SubCategory)
                                           .ToListAsync();
 
             var mappedPosts = mapper.Map<List<PostViewDto>>(postsWithIncludes);


### PR DESCRIPTION
Updated PostProfile.cs to map Category and SubCategory properties in PostViewDto. Added new properties for Category and SubCatgory in PostViewDTO.cs. Modified PostService.cs to include Category and SubCategory in post queries.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add `Category` and `SubCategory` properties to `PostViewDto` mappings and include corresponding data in `PostService`.

### Why are these changes being made?

These changes are being made to enhance the `PostViewDto` by providing additional context for each post, allowing consumers of the `PostViewDto` to see the category and subcategory of each post, which are critical for filtering and presentation purposes in the application. Including these properties streamlines data management, ensuring consistency with domain models and facilitating better user-experience personalization based on categories.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->