### PR TITLE
Change OrderStatusTimeline Status to string

### DIFF
--- a/Dentizone.Application/DTOs/Order/OrderStatusTimeline.cs
+++ b/Dentizone.Application/DTOs/Order/OrderStatusTimeline.cs
@@ -1,9 +1,7 @@
-﻿using Dentizone.Domain.Enums;
-
-namespace Dentizone.Application.DTOs.Order;
+﻿namespace Dentizone.Application.DTOs.Order;
 
 public class OrderStatusTimeline
 {
-    public OrderStatues Status { get; set; }
+    public string Status { get; set; }
     public DateTime Timestamp { get; set; }
 }


### PR DESCRIPTION
Replaces the OrderStatues enum type with a string for the Status property in OrderStatusTimeline. This may improve flexibility or decouple the DTO from domain enums.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Convert the `Status` property in `OrderStatusTimeline` from the `OrderStatues` enum type to a `string`.

### Why are these changes being made?

This change allows for greater flexibility in handling order status values, accommodating statuses that may not be predefined in the `OrderStatues` enum and simplifying integration with systems that use string-based status representations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the order status field to use a text value instead of a predefined list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->