### PR TITLE
Add Failed status to WithdrawalRequestStatus enum

### DIFF
--- a/Dentizone.Domain/Enums/WithdrawalRequestStatus.cs
+++ b/Dentizone.Domain/Enums/WithdrawalRequestStatus.cs
@@ -6,5 +6,6 @@
         Approved, // Request has been approved and is being processed
         Rejected, // Request has been rejected
         Completed, // Withdrawal has been successfully completed
+        Failed
     }
 }


### PR DESCRIPTION
This commit introduces a new status, `Failed`, to the `WithdrawalRequestStatus` enumeration. This status indicates that a withdrawal request has failed.